### PR TITLE
Improve DeltaMesh discovery base URL handling

### DIFF
--- a/web/deltamesh.go
+++ b/web/deltamesh.go
@@ -1,0 +1,125 @@
+package web
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/deemkeen/stegodon/util"
+	"github.com/gin-gonic/gin"
+)
+
+// DeltaMeshWellKnown represents the discovery document advertised from /.well-known/deltamesh.
+// The structure is intentionally small so we can evolve it alongside the protocol draft once
+// the full specification is available locally.
+type DeltaMeshWellKnown struct {
+	Version        string            `json:"version"`
+	Implementation string            `json:"implementation"`
+	Node           string            `json:"node"`
+	Capabilities   []string          `json:"capabilities"`
+	Endpoints      map[string]string `json:"endpoints"`
+}
+
+// DeltaMeshNode describes the current node status for quick health checks.
+type DeltaMeshNode struct {
+	Node           string    `json:"node"`
+	Implementation string    `json:"implementation"`
+	Version        string    `json:"version"`
+	GeneratedAt    time.Time `json:"generatedAt"`
+}
+
+// DeltaMeshRepositoryCatalog is a placeholder collection of repositories advertised by this node.
+// The spec in the git-federation branch calls for a catalog resource; we ship an empty catalog
+// that can be filled in once repository exposure rules are finalized.
+type DeltaMeshRepositoryCatalog struct {
+	Repositories []string `json:"repositories"`
+}
+
+func registerDeltaMeshRoutes(g *gin.Engine, conf *util.AppConfig) {
+	g.GET("/.well-known/deltamesh", func(c *gin.Context) {
+		base := resolvePublicBase(conf, c.Request)
+
+		c.JSON(200, DeltaMeshWellKnown{
+			Version:        "draft-01",
+			Implementation: "stegodon",
+			Node:           base,
+			Capabilities:   []string{"catalog", "status"},
+			Endpoints: map[string]string{
+				"node":      fmt.Sprintf("%s/deltamesh/node", base),
+				"catalog":   fmt.Sprintf("%s/deltamesh/repos", base),
+				"wellKnown": fmt.Sprintf("%s/.well-known/deltamesh", base),
+			},
+		})
+	})
+
+	g.GET("/deltamesh/node", func(c *gin.Context) {
+		base := resolvePublicBase(conf, c.Request)
+		c.JSON(200, DeltaMeshNode{
+			Node:           base,
+			Implementation: "stegodon",
+			Version:        "draft-01",
+			GeneratedAt:    time.Now().UTC(),
+		})
+	})
+
+	g.GET("/deltamesh/repos", func(c *gin.Context) {
+		c.JSON(200, DeltaMeshRepositoryCatalog{Repositories: []string{}})
+	})
+}
+
+func resolvePublicBase(conf *util.AppConfig, req *http.Request) string {
+	scheme, host := requestOrigin(req)
+	if scheme != "" && host != "" {
+		return fmt.Sprintf("%s://%s", scheme, host)
+	}
+
+	if conf == nil {
+		return ""
+	}
+
+	if conf.Conf.SslDomain != "" {
+		return fmt.Sprintf("https://%s", conf.Conf.SslDomain)
+	}
+
+	host = conf.Conf.Host
+	if host == "" {
+		host = "localhost"
+	}
+
+	port := conf.Conf.HttpPort
+	if port <= 0 {
+		port = 80
+	}
+
+	// Preserve literal host if it already includes a port to avoid double-appending.
+	if strings.Contains(host, ":") && strings.Count(host, ":") == 1 {
+		return fmt.Sprintf("http://%s", host)
+	}
+
+	return fmt.Sprintf("http://%s", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
+}
+
+func requestOrigin(req *http.Request) (string, string) {
+	if req == nil {
+		return "", ""
+	}
+
+	proto := strings.TrimSpace(req.Header.Get("X-Forwarded-Proto"))
+	host := strings.TrimSpace(req.Header.Get("X-Forwarded-Host"))
+
+	if proto == "" {
+		if req.TLS != nil {
+			proto = "https"
+		} else {
+			proto = "http"
+		}
+	}
+
+	if host == "" {
+		host = req.Host
+	}
+
+	return proto, host
+}

--- a/web/deltamesh_test.go
+++ b/web/deltamesh_test.go
@@ -1,0 +1,117 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/deemkeen/stegodon/util"
+	"github.com/gin-gonic/gin"
+)
+
+func TestResolvePublicBase(t *testing.T) {
+	conf := &util.AppConfig{}
+	conf.Conf.Host = "127.0.0.1"
+	conf.Conf.HttpPort = 9999
+
+	t.Run("config fallback", func(t *testing.T) {
+		if got := resolvePublicBase(conf, nil); got != "http://127.0.0.1:9999" {
+			t.Fatalf("expected fallback http base, got %s", got)
+		}
+	})
+
+	t.Run("ssl domain", func(t *testing.T) {
+		conf.Conf.SslDomain = "example.com"
+		if got := resolvePublicBase(conf, nil); got != "https://example.com" {
+			t.Fatalf("expected SSL domain base, got %s", got)
+		}
+	})
+
+	t.Run("forwarded headers", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("X-Forwarded-Proto", "https")
+		req.Header.Set("X-Forwarded-Host", "forwarded.example")
+
+		if got := resolvePublicBase(conf, req); got != "https://forwarded.example" {
+			t.Fatalf("expected forwarded origin, got %s", got)
+		}
+	})
+}
+
+func TestDeltaMeshRoutes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	conf := &util.AppConfig{}
+	conf.Conf.Host = "127.0.0.1"
+	conf.Conf.HttpPort = 4242
+
+	r := gin.New()
+	registerDeltaMeshRoutes(r, conf)
+
+	t.Run("well-known", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/.well-known/deltamesh", nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("unexpected status: %d", rr.Code)
+		}
+
+		var payload DeltaMeshWellKnown
+		if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+			t.Fatalf("failed to decode payload: %v", err)
+		}
+
+		expectedBase := "http://127.0.0.1:4242"
+		if payload.Node != expectedBase {
+			t.Fatalf("expected node %s, got %s", expectedBase, payload.Node)
+		}
+
+		if payload.Endpoints["node"] != expectedBase+"/deltamesh/node" {
+			t.Fatalf("unexpected node endpoint: %s", payload.Endpoints["node"])
+		}
+	})
+
+	t.Run("node status", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/deltamesh/node", nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("unexpected status: %d", rr.Code)
+		}
+
+		var payload DeltaMeshNode
+		if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+			t.Fatalf("failed to decode payload: %v", err)
+		}
+
+		if payload.Implementation != "stegodon" {
+			t.Fatalf("unexpected implementation: %s", payload.Implementation)
+		}
+
+		if payload.Node == "" {
+			t.Fatalf("expected node identifier to be set")
+		}
+	})
+
+	t.Run("catalog", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/deltamesh/repos", nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("unexpected status: %d", rr.Code)
+		}
+
+		var payload DeltaMeshRepositoryCatalog
+		if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+			t.Fatalf("failed to decode payload: %v", err)
+		}
+
+		if len(payload.Repositories) != 0 {
+			t.Fatalf("expected empty catalog, got %d entries", len(payload.Repositories))
+		}
+	})
+}

--- a/web/router.go
+++ b/web/router.go
@@ -35,6 +35,8 @@ func Router(conf *util.AppConfig) error {
 	globalLimiter := NewRateLimiter(rate.Limit(10), 20)
 	g.Use(RateLimitMiddleware(globalLimiter))
 
+	registerDeltaMeshRoutes(g, conf)
+
 	// Load HTML templates from embedded filesystem
 	tmpl, err := template.ParseFS(embeddedTemplates, "templates/*.html")
 	if err != nil {


### PR DESCRIPTION
## Summary
- derive the DeltaMesh discovery base URL from incoming request headers when present, so reverse-proxied hosts are reported correctly
- build discovery responses per request and keep the node version consistent with the advertised draft level
- add coverage for forwarded header handling and the updated base resolution helper

## Testing
- `go test ./web -run TestResolvePublicBase -count=1` *(hangs in this environment; interrupted)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e6079a3d08333974b297b08d8814f)