### PR TITLE
Change host IP from 127.0.0.1 to 0.0.0.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 conf:
-  host: 127.0.0.1 # local server ip
+  host: 0.0.0.0 # local server ip
   sshPort: 23232 # ssh login port
   httpPort: 9999 # local http port
   sslDomain: example.com  # your hosted ssl domain (use ngrok domain for local testing)


### PR DESCRIPTION
This allows for connecting locally from other machines, and if configured in one's firewall, remotely from other machines. By default 127.0.0.1 only allows connections from that very machine. Since this is not documented as such, I think this is a better default config since it's up to external configurations to allow other styles of connection (remote connections).

I didn't catch this at first and so I was wondering why I couldn't connect at all from my other machine.

If this was meant for security reasons, then you might want to mention that one will need to change it to 0.0.0.0 in order for other machines to connect to it. If so, this can be closed.