### PR TITLE
Fix CLI post command not federating notes

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -18,6 +18,7 @@ type Session interface {
 // Database interface for CLI operations
 type Database interface {
 	CreateNote(userId interface{}, message string) (interface{}, error)
+	ReadNoteIdWithReplyInfo(id interface{}) (error, *domain.Note)
 	ReadHomeTimelinePosts(accountId interface{}, limit int) (error, *[]domain.HomePost)
 	ReadNotificationsByAccountId(accountId interface{}, limit int) (error, *[]domain.Notification)
 	CountUnreadNotifications(accountId interface{}) (int, error)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -53,6 +53,15 @@ func (m *mockDatabase) CreateNote(userId interface{}, message string) (interface
 	return m.createdNoteID, nil
 }
 
+func (m *mockDatabase) ReadNoteIdWithReplyInfo(id interface{}) (error, *domain.Note) {
+	noteId := id.(uuid.UUID)
+	return nil, &domain.Note{
+		Id:        noteId,
+		CreatedBy: "testuser",
+		Message:   "test message",
+	}
+}
+
 func (m *mockDatabase) ReadHomeTimelinePosts(accountId interface{}, limit int) (error, *[]domain.HomePost) {
 	posts := m.notes
 	if len(posts) > limit {

--- a/middleware/maintui.go
+++ b/middleware/maintui.go
@@ -81,6 +81,10 @@ func (w *dbWrapper) CreateNote(userId interface{}, message string) (interface{},
 	return w.db.CreateNote(userId.(uuid.UUID), message)
 }
 
+func (w *dbWrapper) ReadNoteIdWithReplyInfo(id interface{}) (error, *domain.Note) {
+	return w.db.ReadNoteIdWithReplyInfo(id.(uuid.UUID))
+}
+
 func (w *dbWrapper) ReadHomeTimelinePosts(accountId interface{}, limit int) (error, *[]domain.HomePost) {
 	return w.db.ReadHomeTimelinePosts(accountId.(uuid.UUID), limit)
 }


### PR DESCRIPTION
## Summary
- Fix CLI `post` command not federating notes via ActivityPub
- Notes were being saved to database but not sent to followers

## Problem
The CLI `handlePost` function only called `CreateNote` without triggering federation, unlike the TUI which spawns a goroutine to call `activitypub.SendCreate()`.

## Changes
- **cli/cli.go**: Add `ReadNoteIdWithReplyInfo` to Database interface
- **cli/post.go**: Add federation goroutine after note creation (same pattern as TUI)
- **middleware/maintui.go**: Add wrapper method for new interface function
- **cli/cli_test.go**: Add mock implementation

## Test plan
- [ ] Post via CLI with ActivityPub enabled
- [ ] Verify note appears on remote followers' timelines
- [ ] Run `go test ./cli/...` - all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)