### PR TITLE
Use object.url for web links instead of object.id

### DIFF
--- a/db/db_test.go
+++ b/db/db_test.go
@@ -85,6 +85,7 @@ func setupTestDB(t *testing.T) *DB {
 		activity_type varchar(50) NOT NULL,
 		actor_uri varchar(500),
 		object_uri varchar(500),
+		object_url TEXT,
 		in_reply_to TEXT,
 		raw_json text,
 		processed int default 0,

--- a/domain/activitypub.go
+++ b/domain/activitypub.go
@@ -55,7 +55,8 @@ type Activity struct {
 	ActivityURI  string
 	ActivityType string // Follow, Create, Like, Announce, Undo, etc.
 	ActorURI     string
-	ObjectURI    string
+	ObjectURI    string // ActivityPub object id (canonical URI, returns JSON)
+	ObjectURL    string // ActivityPub object url (human-readable web UI link)
 	InReplyTo    string // For Create activities, the URI this is a reply to (indexed for fast lookups)
 	RawJSON      string
 	Processed    bool

--- a/domain/notes.go
+++ b/domain/notes.go
@@ -41,7 +41,8 @@ type HomePost struct {
 	Author     string // @user (local) or @user@domain (remote)
 	Content    string
 	Time       time.Time
-	ObjectURI  string
+	ObjectURI  string // ActivityPub object id (canonical URI, returns JSON)
+	ObjectURL  string // ActivityPub object url (human-readable web UI link, preferred for display)
 	IsLocal    bool      // true = local note, false = remote activity
 	NoteID     uuid.UUID // only set for local posts (for editing/deleting)
 	ReplyCount int       // number of replies to this post

--- a/ui/hometimeline/hometimeline.go
+++ b/ui/hometimeline/hometimeline.go
@@ -172,9 +172,14 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			m.showingEngagement = false
 		case "o":
 			// Toggle between showing content and URL (only for posts with valid HTTP/HTTPS URLs)
+			// Prefer ObjectURL (web UI link) over ObjectURI (ActivityPub id/JSON)
 			if len(m.Posts) > 0 && m.Selected < len(m.Posts) {
 				selectedPost := m.Posts[m.Selected]
-				if util.IsURL(selectedPost.ObjectURI) {
+				displayURL := selectedPost.ObjectURL
+				if displayURL == "" {
+					displayURL = selectedPost.ObjectURI
+				}
+				if util.IsURL(displayURL) {
 					m.showingURL = !m.showingURL
 				}
 			}
@@ -385,8 +390,13 @@ func (m Model) View() string {
 					s.WriteString(timeFormatted + "\n")
 					s.WriteString(authorFormatted + "\n")
 					s.WriteString(contentFormatted)
-				} else if m.showingURL && post.ObjectURI != "" {
-					osc8Link := util.FormatClickableURL(post.ObjectURI, common.MaxContentTruncateWidth, "🔗 ")
+				} else if m.showingURL {
+					// Prefer ObjectURL (web UI link) over ObjectURI (ActivityPub id/JSON)
+					displayURL := post.ObjectURL
+					if displayURL == "" {
+						displayURL = post.ObjectURI
+					}
+					osc8Link := util.FormatClickableURL(displayURL, common.MaxContentTruncateWidth, "🔗 ")
 					hintText := "(Cmd+click to open, press 'o' to toggle back)"
 
 					contentStyleBg := lipgloss.NewStyle().

--- a/web/ui.go
+++ b/web/ui.go
@@ -647,12 +647,18 @@ func HandleSinglePost(c *gin.Context, conf *util.AppConfig) {
 					}
 				}
 
+				// Prefer ObjectURL (web UI link) over ObjectURI (ActivityPub id/JSON)
+				postURL := activity.ObjectURL
+				if postURL == "" {
+					postURL = activity.ObjectURI
+				}
+
 				replies = append(replies, PostView{
 					NoteId:      activity.Id.String(),
 					Username:    replyUsername,
 					UserDomain:  replyDomain,
 					ProfileURL:  replyProfileURL,
-					PostURL:     activity.ObjectURI,
+					PostURL:     postURL,
 					IsRemote:    true,
 					Message:     replyContent,
 					MessageHTML: template.HTML(replyMessageHTML),


### PR DESCRIPTION
## Summary
- Extract and store `object.url` (web UI link) alongside `object.id` (ActivityPub URI) from incoming activities
- Prefer `object.url` for display links in both TUI and web UI
- Add migration to backfill existing activities from their raw_json

## Problem
Remote post links in TUI ('o' key) and web UI replies pointed to `/notes/{uuid}` which returns ActivityPub JSON instead of the web UI. For example, clicking a link to a remote Stegodon user's post would show JSON instead of the readable web page.

## Solution
ActivityPub objects have two URLs:
- `id`: Canonical ActivityPub URI (returns JSON, e.g., `https://domain/notes/uuid`)
- `url`: Human-readable web UI link (returns HTML, e.g., `https://domain/u/username/uuid`)

Now we store and prefer `object.url` when available, falling back to `object.id` if not present.

## Test plan
- [x] Run `go test ./...` - all tests pass
- [x] Build succeeds with `go build`
- [ ] Test TUI 'o' key on remote posts - should show web UI link
- [ ] Test web UI remote reply links - should link to web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)