### PR TITLE
Make Stegodon title clickable to navigate home

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -46,6 +46,15 @@ body {
     "Liberation Mono", "Courier New", monospace;
 }
 
+.sidebar h1 a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.sidebar h1 a:hover {
+  text-decoration: underline;
+}
+
 .sidebar h1 .emoji {
   filter: grayscale(100%) sepia(100%) saturate(1000%) hue-rotate(90deg)
     brightness(1.2);

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -33,7 +33,7 @@
         <div class="layout">
             <div class="sidebar minimized">
                 <div class="sidebar-header">
-                    <h1><span class="emoji">🦣</span> stegodon</h1>
+                    <h1><a href="/"><span class="emoji">🦣</span> stegodon</a></h1>
                     <span class="version">v{{.Version}}</span>
                     <span class="toggle-btn"><span></span><span></span><span></span></span>
                 </div>

--- a/web/templates/post.html
+++ b/web/templates/post.html
@@ -33,7 +33,7 @@
         <div class="layout">
             <div class="sidebar minimized">
                 <div class="sidebar-header">
-                    <h1><span class="emoji">🦣</span> stegodon</h1>
+                    <h1><a href="/"><span class="emoji">🦣</span> stegodon</a></h1>
                     <span class="version">v{{.Version}}</span>
                     <span class="toggle-btn"><span></span><span></span><span></span></span>
                 </div>

--- a/web/templates/profile.html
+++ b/web/templates/profile.html
@@ -34,7 +34,7 @@
         <div class="layout">
             <div class="sidebar minimized">
                 <div class="sidebar-header">
-                    <h1><span class="emoji">🦣</span> stegodon</h1>
+                    <h1><a href="/"><span class="emoji">🦣</span> stegodon</a></h1>
                     <span class="version">v{{.Version}}</span>
                     <span class="toggle-btn"><span></span><span></span><span></span></span>
                 </div>

--- a/web/templates/tag.html
+++ b/web/templates/tag.html
@@ -33,7 +33,7 @@
         <div class="layout">
             <div class="sidebar minimized">
                 <div class="sidebar-header">
-                    <h1><span class="emoji">🦣</span> stegodon</h1>
+                    <h1><a href="/"><span class="emoji">🦣</span> stegodon</a></h1>
                     <span class="version">v{{.Version}}</span>
                     <span class="toggle-btn"><span></span><span></span><span></span></span>
                 </div>


### PR DESCRIPTION
Wrap the sidebar title in an anchor tag linking to "/" so users can click on "stegodon" from any page to return to the home timeline.