### PR TITLE
Implement user-initiated boosts (Issue #70)

### DIFF
--- a/db/db_test.go
+++ b/db/db_test.go
@@ -109,6 +109,16 @@ func setupTestDB(t *testing.T) *DB {
 		UNIQUE(account_id, note_id)
 	)`)
 
+	db.db.Exec(`CREATE TABLE IF NOT EXISTS boosts(
+		id uuid NOT NULL PRIMARY KEY,
+		account_id uuid NOT NULL,
+		note_id uuid NOT NULL,
+		uri varchar(500),
+		object_uri TEXT,
+		created_at timestamp default current_timestamp,
+		UNIQUE(account_id, note_id)
+	)`)
+
 	db.db.Exec(`CREATE TABLE IF NOT EXISTS delivery_queue(
 		id uuid NOT NULL PRIMARY KEY,
 		inbox_uri varchar(500) NOT NULL,

--- a/domain/notes.go
+++ b/domain/notes.go
@@ -26,6 +26,7 @@ type GlobalTimelinePost struct {
 	ReplyCount  int
 	LikeCount   int
 	BoostCount  int
+	BoostedBy   string // if non-empty, this post was boosted by this user (e.g., "@alice" or "@bob@domain")
 }
 
 type Note struct {
@@ -64,4 +65,5 @@ type HomePost struct {
 	ReplyCount int       // number of replies to this post
 	LikeCount  int       // number of likes on this post
 	BoostCount int       // number of boosts on this post
+	BoostedBy  string    // if non-empty, this post was boosted by this user (e.g., "@alice" or "@bob@domain")
 }

--- a/ui/common/commands.go
+++ b/ui/common/commands.go
@@ -72,3 +72,10 @@ type LikeNoteMsg struct {
 	NoteID  uuid.UUID // Local UUID (if local note)
 	IsLocal bool      // Whether this is a local note
 }
+
+// BoostNoteMsg is sent when user presses 'b' to boost/unboost a post
+type BoostNoteMsg struct {
+	NoteURI string    // ActivityPub object URI of the note being boosted
+	NoteID  uuid.UUID // Local UUID (if local note)
+	IsLocal bool      // Whether this is a local note
+}

--- a/ui/myposts/notepager.go
+++ b/ui/myposts/notepager.go
@@ -161,6 +161,23 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 					}
 				}
 			}
+		case "b":
+			// Boost/unboost selected note
+			if len(m.Notes) > 0 && m.Selected < len(m.Notes) {
+				selectedNote := m.Notes[m.Selected]
+				noteURI := selectedNote.ObjectURI
+				// For local notes without ObjectURI, use local: prefix
+				if noteURI == "" {
+					noteURI = "local:" + selectedNote.Id.String()
+				}
+				return m, func() tea.Msg {
+					return common.BoostNoteMsg{
+						NoteURI: noteURI,
+						NoteID:  selectedNote.Id,
+						IsLocal: true, // myposts only shows local notes
+					}
+				}
+			}
 		}
 	}
 	return m, nil

--- a/ui/notifications/notifications.go
+++ b/ui/notifications/notifications.go
@@ -31,6 +31,7 @@ type Model struct {
 	Width         int
 	Height        int
 	isActive      bool
+	tickerRunning bool // Track if refresh ticker is already running
 	UnreadCount   int
 	Status        string
 	Error         string
@@ -185,8 +186,12 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		if m.Selected < 0 {
 			m.Selected = 0
 		}
-		// Schedule next tick to keep badge updated
-		return m, tickRefresh()
+		// Schedule next tick to keep badge updated (only if not already running)
+		if !m.tickerRunning {
+			m.tickerRunning = true
+			return m, tickRefresh()
+		}
+		return m, nil
 
 	case refreshTickMsg:
 		// Always refresh to keep badge count updated

--- a/ui/threadview/threadview.go
+++ b/ui/threadview/threadview.go
@@ -675,6 +675,40 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 					}
 				}
 			}
+		case "b":
+			// Boost/unboost selected post
+			if m.Selected == -1 && m.ParentPost != nil && !m.ParentPost.IsDeleted {
+				// Boost the parent post
+				noteURI := m.ParentPost.ObjectURI
+				if noteURI == "" && m.ParentPost.IsLocal && m.ParentPost.ID != uuid.Nil {
+					noteURI = "local:" + m.ParentPost.ID.String()
+				}
+				if noteURI != "" || m.ParentPost.ID != uuid.Nil {
+					return m, func() tea.Msg {
+						return common.BoostNoteMsg{
+							NoteURI: noteURI,
+							NoteID:  m.ParentPost.ID,
+							IsLocal: m.ParentPost.IsLocal,
+						}
+					}
+				}
+			} else if m.Selected >= 0 && m.Selected < len(m.Replies) {
+				// Boost a reply
+				reply := m.Replies[m.Selected]
+				noteURI := reply.ObjectURI
+				if noteURI == "" && reply.IsLocal && reply.ID != uuid.Nil {
+					noteURI = "local:" + reply.ID.String()
+				}
+				if noteURI != "" || reply.ID != uuid.Nil {
+					return m, func() tea.Msg {
+						return common.BoostNoteMsg{
+							NoteURI: noteURI,
+							NoteID:  reply.ID,
+							IsLocal: reply.IsLocal,
+						}
+					}
+				}
+			}
 		case "o":
 			// Toggle between showing content and URL (only for posts with valid HTTP/HTTPS URLs)
 			// Prefer ObjectURL (web UI link) over ObjectURI (ActivityPub id/JSON)

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -347,6 +347,18 @@ h2 {
   margin-bottom: 20px;
 }
 
+.boost-indicator {
+  background: #1a1a2e;
+  padding: 4px 10px;
+  font-size: 12px;
+  color: #888;
+  font-style: italic;
+}
+
+.boost-indicator .boost-icon {
+  margin-right: 4px;
+}
+
 .post-meta {
   background: #181818;
   border-bottom: 1px solid #333;

--- a/web/templates/global.html
+++ b/web/templates/global.html
@@ -70,6 +70,11 @@
 
                     {{if .Posts}} {{range .Posts}}
                     <div class="post">
+                        {{if .BoostedBy}}
+                        <div class="boost-indicator">
+                            <span class="boost-icon">🔁</span> {{.BoostedBy}} boosted
+                        </div>
+                        {{end}}
                         <div class="post-meta">
                             {{if .IsRemote}}
                                 <a href="{{.ProfileURL}}" class="post-author remote-author" target="_blank" rel="noopener noreferrer">{{.Username}}</a>
@@ -89,12 +94,12 @@
                         {{if or (gt .ReplyCount 0) (gt .LikeCount 0) (gt .BoostCount 0)}}
                         <div class="post-footer">
                             {{if gt .LikeCount 0}}
-                                <span class="like-count engagement-trigger" data-type="likes" data-note-id="{{.NoteId}}" data-object-uri="{{.PostURL}}" data-is-remote="{{.IsRemote}}" style="cursor: pointer;">
+                                <span class="like-count engagement-trigger" data-type="likes" data-note-id="{{.NoteId}}" data-object-uri="{{.ObjectURI}}" data-is-remote="{{.IsRemote}}" style="cursor: pointer;">
                                     <span class="icon">⭐</span> {{.LikeCount}}
                                 </span>
                             {{end}}
                             {{if gt .BoostCount 0}}
-                                <span class="boost-count engagement-trigger" data-type="boosts" data-note-id="{{.NoteId}}" data-object-uri="{{.PostURL}}" data-is-remote="{{.IsRemote}}" style="cursor: pointer;">
+                                <span class="boost-count engagement-trigger" data-type="boosts" data-note-id="{{.NoteId}}" data-object-uri="{{.ObjectURI}}" data-is-remote="{{.IsRemote}}" style="cursor: pointer;">
                                     <span class="icon">🔁</span> {{.BoostCount}}
                                 </span>
                             {{end}}

--- a/web/ui.go
+++ b/web/ui.go
@@ -70,7 +70,8 @@ type PostView struct {
 	Username     string
 	UserDomain   string // Domain for remote users (empty for local)
 	ProfileURL   string // Full profile URL
-	PostURL      string // Permalink to the post (remote object_uri or local path)
+	PostURL      string // Permalink to the post (web URL for display)
+	ObjectURI    string // ActivityPub canonical URI (for API calls)
 	IsRemote     bool   // True if federated user
 	Message      string
 	MessageHTML  template.HTML // HTML-rendered message with clickable links
@@ -82,6 +83,7 @@ type PostView struct {
 	BoostCount   int       // Number of boosts on this post
 	Likers       []string  // Usernames who liked this post
 	Boosters     []string  // Usernames who boosted this post
+	BoostedBy    string    // If non-empty, this post was boosted by this user
 }
 
 // convertMarkdownToHTML converts markdown text to HTML
@@ -769,6 +771,7 @@ func HandleGlobalTimeline(c *gin.Context, conf *util.AppConfig) {
 			UserDomain:  post.UserDomain,
 			ProfileURL:  post.ProfileURL,
 			PostURL:     displayURL,
+			ObjectURI:   post.ObjectURI,
 			IsRemote:    post.IsRemote,
 			Message:     post.Message,
 			MessageHTML: template.HTML(messageHTML),
@@ -777,6 +780,7 @@ func HandleGlobalTimeline(c *gin.Context, conf *util.AppConfig) {
 			ReplyCount:  post.ReplyCount,
 			LikeCount:   post.LikeCount,
 			BoostCount:  post.BoostCount,
+			BoostedBy:   post.BoostedBy,
 		}
 		postViews = append(postViews, postView)
 	}


### PR DESCRIPTION
## Summary

- Add ability for users to boost/unboost posts via TUI ('b' key binding)
- Add SendAnnounce/SendUndoAnnounce ActivityPub functions for federation
- Add ObjectURI-based boost database operations for remote posts
- Display boost indicator in web UI global timeline
- Fix goroutine leak in auto-refresh views (tickerRunning flag)
- Fix SQLite timestamp parsing (Z suffix treated as local time, not UTC)

## Test plan

- [ ] Connect via SSH, navigate to a post, press 'b' to boost
- [ ] Verify boost count increments and booster appears in 'i' info view
- [ ] Press 'b' again to unboost, verify count decrements
- [ ] Check web UI global timeline shows "🔁 @user boosted" indicator
- [ ] Verify timestamps display correctly (not "just now" for old boosts)
- [ ] If AP enabled: verify Announce activity sent to remote servers

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)