### PR TITLE
Fix global timeline showing posts from unfollowed users

### DIFF
--- a/activitypub/mock_db_test.go
+++ b/activitypub/mock_db_test.go
@@ -106,6 +106,9 @@ func (m *MockDatabase) AddActivity(activity *domain.Activity) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.Activities[activity.Id] = activity
+	if activity.ActivityURI != "" {
+		m.ActivitiesByURI[activity.ActivityURI] = activity
+	}
 	if activity.ObjectURI != "" {
 		m.ActivitiesByObj[activity.ObjectURI] = activity
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -78,6 +78,15 @@ func (a *App) Initialize() error {
 		log.Printf("Warning: Performance indexes migration encountered errors: %v", err)
 	}
 
+	// Run orphan activities cleanup migration (fixes bug where Create activities
+	// were stored before checking follow relationships)
+	log.Println("Checking for orphan activities...")
+	if err := database.MigrateOrphanActivities(); err != nil {
+		log.Printf("Warning: Orphan activities migration encountered errors: %v", err)
+	} else {
+		log.Println("Orphan activities migration complete")
+	}
+
 	// Cleanup expired IP bans (IP addresses older than 60 days are cleared)
 	database.CleanupExpiredIPBans()
 


### PR DESCRIPTION
## Summary

- Fix inbox handler storing Create activities before acceptance check
- Add migration to clean up orphan activities already in the database
- Add comprehensive tests for activity storage behavior

Fixes #84

## Problem

The `HandleInboxWithDeps` function in `activitypub/inbox.go` was storing incoming Create activities to the database **before** checking if the activity should be accepted. When the acceptance check failed (no follow relationship, not from relay, not a reply to local post), the activity was already stored and would appear in the global timeline.

## Solution

1. **Inbox fix**: Skip pre-storing Create activities in `HandleInboxWithDeps`. Move storage to inside `handleCreateActivityWithDeps` after acceptance criteria are validated.

2. **Migration**: Add `MigrateOrphanActivities()` to clean up activities that:
   - Are type `Create` with `local=0` and `from_relay=0`
   - Have no follow relationship with any local user
   - Are not replies to local notes

3. **Tests**: Add 5 new tests verifying:
   - Rejected activities are NOT stored
   - Followed user activities ARE stored  
   - Relay content IS stored (even without follow)
   - Replies to our posts ARE stored (even without follow)
   - Duplicate activities are handled gracefully

## Test plan

- [x] All existing tests pass
- [x] New tests verify correct storage behavior
- [x] Migration query tested against real database (747 orphan activities found)
- [ ] Manual test: run server, verify global timeline no longer shows unfollowed users' posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)