### PR TITLE
Show boosts from remote followed users in timeline

### DIFF
--- a/activitypub/db_wrapper.go
+++ b/activitypub/db_wrapper.go
@@ -178,6 +178,20 @@ func (w *DBWrapper) DecrementBoostCountByNoteId(noteId uuid.UUID) error {
 	return w.db.DecrementBoostCountByNoteId(noteId)
 }
 
+// Remote boost operations
+
+func (w *DBWrapper) IsRemoteAccountFollowed(remoteAccountId uuid.UUID) (bool, error) {
+	return w.db.IsRemoteAccountFollowed(remoteAccountId)
+}
+
+func (w *DBWrapper) CreateBoostFromRemote(boost *domain.Boost) error {
+	return w.db.CreateBoostFromRemote(boost)
+}
+
+func (w *DBWrapper) HasBoostFromRemote(remoteAccountId uuid.UUID, objectURI string) (bool, error) {
+	return w.db.HasBoostFromRemote(remoteAccountId, objectURI)
+}
+
 // Delivery queue operations
 
 func (w *DBWrapper) EnqueueDelivery(item *domain.DeliveryQueueItem) error {

--- a/activitypub/deps.go
+++ b/activitypub/deps.go
@@ -64,6 +64,11 @@ type Database interface {
 	IncrementBoostCountByNoteId(noteId uuid.UUID) error
 	DecrementBoostCountByNoteId(noteId uuid.UUID) error
 
+	// Remote boost operations (for boosts from followed remote users)
+	IsRemoteAccountFollowed(remoteAccountId uuid.UUID) (bool, error)
+	CreateBoostFromRemote(boost *domain.Boost) error
+	HasBoostFromRemote(remoteAccountId uuid.UUID, objectURI string) (bool, error)
+
 	// Delivery queue operations
 	EnqueueDelivery(item *domain.DeliveryQueueItem) error
 	ReadPendingDeliveries(limit int) (error, *[]domain.DeliveryQueueItem)

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -111,7 +111,8 @@ func setupTestDB(t *testing.T) *DB {
 
 	db.db.Exec(`CREATE TABLE IF NOT EXISTS boosts(
 		id uuid NOT NULL PRIMARY KEY,
-		account_id uuid NOT NULL,
+		account_id uuid,
+		remote_account_id uuid,
 		note_id uuid NOT NULL,
 		uri varchar(500),
 		object_uri TEXT,

--- a/domain/activitypub.go
+++ b/domain/activitypub.go
@@ -42,11 +42,13 @@ type Like struct {
 
 // Boost represents a boost/reblog/announce on a note
 type Boost struct {
-	Id        uuid.UUID
-	AccountId uuid.UUID // Who boosted (can be local or remote)
-	NoteId    uuid.UUID // Which note was boosted
-	URI       string    // ActivityPub Announce activity URI
-	CreatedAt time.Time
+	Id              uuid.UUID
+	AccountId       uuid.UUID // Who boosted (local account, nil for remote booster)
+	RemoteAccountId uuid.UUID // Who boosted (remote account, nil for local booster)
+	NoteId          uuid.UUID // Which local note was boosted (nil if boosting remote post)
+	ObjectURI       string    // URI of the boosted object (for remote posts)
+	URI             string    // ActivityPub Announce activity URI
+	CreatedAt       time.Time
 }
 
 // Activity represents an ActivityPub activity (for logging/deduplication)


### PR DESCRIPTION
## Summary
- When a remote user you follow boosts a post, it now appears in your home timeline
- Fetches and stores the boosted content if it doesn't exist locally
- Displays remote boosters as `@username@domain boosted` in timeline

## Changes
- Add `remote_account_id` column to boosts table for tracking remote boosters
- Update `Boost` struct with `RemoteAccountId` and `ObjectURI` fields
- Modify Announce handler to fetch boosted content when booster is followed
- Update home/global timeline queries to include boosts from remote users
- Add composite index `idx_boosts_remote_created` for efficient queries
- Optimize `IsRemoteAccountFollowed` with `LIMIT 1` for early termination

## Test plan
- [x] Unit tests for followed remote user boost handling
- [x] Unit tests for unfollowed remote user (should be ignored)
- [x] Unit tests for duplicate boost deduplication
- [x] Manual test: Follow a remote user who boosts posts, verify boosts appear in home timeline
- [x] Manual test: Verify boosts show `@username@domain boosted` indicator
- [ ] Manual test: Verify existing local boosts still work (backward compatibility)

Fixes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)