### PR TITLE
Fix Undo(Announce) not processing correctly for remote posts

### DIFF
--- a/activitypub/db_wrapper.go
+++ b/activitypub/db_wrapper.go
@@ -192,6 +192,14 @@ func (w *DBWrapper) HasBoostFromRemote(remoteAccountId uuid.UUID, objectURI stri
 	return w.db.HasBoostFromRemote(remoteAccountId, objectURI)
 }
 
+func (w *DBWrapper) DeleteBoostByRemoteAccountAndObjectURI(remoteAccountId uuid.UUID, objectURI string) error {
+	return w.db.DeleteBoostByRemoteAccountAndObjectURI(remoteAccountId, objectURI)
+}
+
+func (w *DBWrapper) DecrementBoostCountByObjectURI(objectURI string) error {
+	return w.db.DecrementBoostCountByObjectURI(objectURI)
+}
+
 // Delivery queue operations
 
 func (w *DBWrapper) EnqueueDelivery(item *domain.DeliveryQueueItem) error {

--- a/activitypub/deps.go
+++ b/activitypub/deps.go
@@ -68,6 +68,8 @@ type Database interface {
 	IsRemoteAccountFollowed(remoteAccountId uuid.UUID) (bool, error)
 	CreateBoostFromRemote(boost *domain.Boost) error
 	HasBoostFromRemote(remoteAccountId uuid.UUID, objectURI string) (bool, error)
+	DeleteBoostByRemoteAccountAndObjectURI(remoteAccountId uuid.UUID, objectURI string) error
+	DecrementBoostCountByObjectURI(objectURI string) error
 
 	// Delivery queue operations
 	EnqueueDelivery(item *domain.DeliveryQueueItem) error

--- a/activitypub/mock_db_test.go
+++ b/activitypub/mock_db_test.go
@@ -711,6 +711,38 @@ func (m *MockDatabase) HasBoostFromRemote(remoteAccountId uuid.UUID, objectURI s
 	return false, nil
 }
 
+func (m *MockDatabase) DeleteBoostByRemoteAccountAndObjectURI(remoteAccountId uuid.UUID, objectURI string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.ForceError != nil {
+		return m.ForceError
+	}
+	for id, boost := range m.Boosts {
+		if boost.RemoteAccountId == remoteAccountId && boost.ObjectURI == objectURI {
+			delete(m.Boosts, id)
+			return nil
+		}
+	}
+	return nil
+}
+
+func (m *MockDatabase) DecrementBoostCountByObjectURI(objectURI string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.ForceError != nil {
+		return m.ForceError
+	}
+	for _, activity := range m.Activities {
+		if activity.ObjectURI == objectURI {
+			if activity.BoostCount > 0 {
+				activity.BoostCount--
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
 // Relay operations
 
 func (m *MockDatabase) CreateRelay(relay *domain.Relay) error {

--- a/db/db.go
+++ b/db/db.go
@@ -3249,6 +3249,15 @@ func (db *DB) HasBoostFromRemote(remoteAccountId uuid.UUID, objectURI string) (b
 	return count > 0, nil
 }
 
+// DeleteBoostByRemoteAccountAndObjectURI removes a boost by remote account ID and object URI
+func (db *DB) DeleteBoostByRemoteAccountAndObjectURI(remoteAccountId uuid.UUID, objectURI string) error {
+	return db.wrapTransaction(func(tx *sql.Tx) error {
+		_, err := tx.Exec(`DELETE FROM boosts WHERE remote_account_id = ? AND object_uri = ?`,
+			remoteAccountId.String(), objectURI)
+		return err
+	})
+}
+
 // Reply query methods
 
 // ReadRepliesByNoteId returns all direct replies to a local note by its UUID


### PR DESCRIPTION
## Summary
- Fixes Undo(Announce) activities from remote users not being processed when the boosted post is a remote post (stored in activities table, not notes table)
- Boosts from followed remote users on remote posts use `remote_account_id` and `object_uri`, which the previous handler didn't check

## Changes
- Add `DeleteBoostByRemoteAccountAndObjectURI()` function to database layer
- Expose `DecrementBoostCountByObjectURI` in Database interface
- Update Undo(Announce) handler to:
  1. First check local notes table
  2. If not found, check for remote post boost via `HasBoostFromRemote`
  3. Delete boost and decrement count on appropriate table

## Test plan
- [x] Added unit test `TestHandleUndoAnnounce_RemotePost`
- [x] All existing tests pass
- [ ] Manual test: Follow remote user, have them boost a remote post, then unboost - verify boost is removed from timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)