### PR TITLE
Add markdown support to server messages in web UI

### DIFF
--- a/web/templates/global.html
+++ b/web/templates/global.html
@@ -63,7 +63,7 @@
                         </div>
                         {{if .ServerMessage}}
                         <div class="server-message">
-                            <strong>📢 Server Message:</strong> {{.ServerMessage.Message}}
+                            <strong>📢 Server Message:</strong> {{.ServerMessage.MessageHTML}}
                         </div>
                         {{end}}
                     </div>

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -65,7 +65,7 @@
                         </div>
                         {{if .ServerMessage}}
                         <div class="server-message">
-                            <strong>📢 Server Message:</strong> {{.ServerMessage.Message}}
+                            <strong>📢 Server Message:</strong> {{.ServerMessage.MessageHTML}}
                         </div>
                         {{end}}
                     </div>

--- a/web/templates/post.html
+++ b/web/templates/post.html
@@ -59,7 +59,7 @@
 
                     {{if .ServerMessage}}
                     <div class="server-message">
-                        <strong>📢 Server Message:</strong> {{.ServerMessage.Message}}
+                        <strong>📢 Server Message:</strong> {{.ServerMessage.MessageHTML}}
                     </div>
                     {{end}}
 

--- a/web/templates/profile.html
+++ b/web/templates/profile.html
@@ -60,7 +60,7 @@
 
                     {{if .ServerMessage}}
                     <div class="server-message">
-                        <strong>📢 Server Message:</strong> {{.ServerMessage.Message}}
+                        <strong>📢 Server Message:</strong> {{.ServerMessage.MessageHTML}}
                     </div>
                     {{end}}
 

--- a/web/templates/tag.html
+++ b/web/templates/tag.html
@@ -59,7 +59,7 @@
 
                     {{if .ServerMessage}}
                     <div class="server-message">
-                        <strong>📢 Server Message:</strong> {{.ServerMessage.Message}}
+                        <strong>📢 Server Message:</strong> {{.ServerMessage.MessageHTML}}
                     </div>
                     {{end}}
 


### PR DESCRIPTION
## Summary
- Enable markdown rendering in server messages on web pages
- Reuses existing `convertMarkdownToHTML()` function used by info boxes
- Allows admins to include clickable links like `[stegodon.zip](https://stegodon.zip)` in server messages

## Changes
- Added `ServerMessageView` struct with `MessageHTML` field for rendered content
- Updated `loadServerMessageForWeb()` to render markdown to HTML
- Updated all 5 web templates to use `MessageHTML` instead of plain `Message`

## Supported Markdown
- **Links**: `[text](url)` → clickable links with `target="_blank"`
- **Bold**: `**text**`
- **Italic**: `*text*`
- **Strikethrough**: `~~text~~`

## Test plan
- [ ] Set server message with markdown link via SSH admin panel
- [ ] Verify link renders correctly on index page
- [ ] Verify link renders correctly on global timeline
- [ ] Verify link renders correctly on profile pages
- [ ] Verify link renders correctly on single post pages
- [ ] Verify link renders correctly on tag pages
- [ ] Verify TUI still shows plain text (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)